### PR TITLE
Prevent NaNs in distilled data generation

### DIFF
--- a/src/data_generate/distill_data.py
+++ b/src/data_generate/distill_data.py
@@ -170,6 +170,15 @@ def generate_calib_centers(args, teacher_model, beta_ce = 5):
                 total_loss.backward()
                 torch.nn.utils.clip_grad_norm_(gaussian_data, max_norm=1.0)
                 optimizer.step()
+
+                # Clamp values to avoid extremely large magnitudes
+                with torch.no_grad():
+                    gaussian_data.clamp_(-10, 10)
+                    # Reinitialize if NaN or Inf appears
+                    if torch.isnan(gaussian_data).any() or torch.isinf(gaussian_data).any():
+                        print("NaN detected in gaussian_data, reinitializing")
+                        gaussian_data.normal_()
+
                 scheduler.step(total_loss.item())
 
             with torch.no_grad():
@@ -510,6 +519,14 @@ class DistillData:
                 total_loss.backward()
                 torch.nn.utils.clip_grad_norm_(gaussian_data, max_norm=1.0)
                 optimizer.step()
+
+                # Clamp values to avoid extremely large magnitudes
+                with torch.no_grad():
+                    gaussian_data.clamp_(-10, 10)
+                    if torch.isnan(gaussian_data).any() or torch.isinf(gaussian_data).any():
+                        print("NaN detected in gaussian_data, reinitializing")
+                        gaussian_data.normal_()
+
                 scheduler.step(total_loss.item())
 
 


### PR DESCRIPTION
## Summary
- avoid NaN by clamping gaussian data during calibration center generation and distilled data generation
- reinitialize gaussian data if NaN or Inf values are detected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687616e6696c832a83e32ffd089554a1