### PR TITLE
Add DSV-based data synthesis option

### DIFF
--- a/src/data_generate/dsv_synthesis.py
+++ b/src/data_generate/dsv_synthesis.py
@@ -1,0 +1,90 @@
+"""DSV-based data synthesis utilities."""
+import os
+import pickle
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from distill_data import check_path
+
+
+def _determine_shape(model_name: str, batch_size: int):
+    """Return input shape for the given model name."""
+    if model_name in ['resnet20_cifar10', 'resnet20_cifar100', 'resnet34_cifar100']:
+        return (batch_size, 3, 32, 32)
+    else:
+        return (batch_size, 3, 224, 224)
+
+
+def _total_variation(x: torch.Tensor) -> torch.Tensor:
+    tv_h = (x[:, :, 1:, :] - x[:, :, :-1, :]).abs().mean()
+    tv_w = (x[:, :, :, 1:] - x[:, :, :, :-1]).abs().mean()
+    return tv_h + tv_w
+
+
+def _image_norm(x: torch.Tensor) -> torch.Tensor:
+    return x.pow(2).mean()
+
+
+def generate_dsv_data(args, model: nn.Module):
+    """Generate synthetic data via Deep Support Vectors.
+
+    Args:
+        args: command line arguments
+        model: pretrained model (frozen)
+    """
+    device = next(model.parameters()).device
+    model.eval()
+    for p in model.parameters():
+        p.requires_grad = False
+
+    # determine input shape and number of classes
+    shape = _determine_shape(args.model, args.num_data)
+    with torch.no_grad():
+        dummy_out = model(torch.randn(1, *shape[1:], device=device))
+        num_classes = dummy_out.shape[1]
+
+    # initialize data and lambdas
+    total = args.num_data
+    labels = torch.arange(num_classes, device=device).repeat_interleave(total // num_classes + 1)[:total]
+    x = torch.randn(total, *shape[1:], device=device, requires_grad=True)
+    lambdas = torch.ones(total, device=device, requires_grad=True)
+
+    theta = [p.detach().clone() for p in model.parameters()]
+    optim = torch.optim.Adam([x, lambdas], lr=getattr(args, 'dsv_lr', 0.1))
+    iters = getattr(args, 'dsv_iter', 200)
+
+    for _ in range(iters):
+        outputs = model(x)
+        ce = F.cross_entropy(outputs, labels, reduction='none')
+        preds = outputs.argmax(dim=1)
+        primal_mask = (preds != labels).float()
+        primal_loss = (ce * primal_mask).mean()
+
+        weighted = (ce * lambdas.relu()).sum()
+        grads = torch.autograd.grad(weighted, model.parameters(), create_graph=True)
+        stat_loss = 0.0
+        for th, g in zip(theta, grads):
+            stat_loss = stat_loss + ((th + g) ** 2).mean()
+
+        tv_loss = _total_variation(x)
+        norm_loss = _image_norm(x)
+        total_loss = stat_loss + args.beta * primal_loss + args.gamma * tv_loss + 1e-5 * norm_loss
+
+        optim.zero_grad()
+        total_loss.backward()
+        optim.step()
+        with torch.no_grad():
+            lambdas.clamp_(min=0.0)
+
+    data_path = os.path.join(args.save_path_head, f"{args.model}_dsv_data.pickle")
+    label_path = os.path.join(args.save_path_head, f"{args.model}_dsv_labels.pickle")
+    check_path(data_path)
+    check_path(label_path)
+    with open(data_path, 'wb') as f:
+        pickle.dump([x.detach().cpu().numpy()], f)
+    with open(label_path, 'wb') as f:
+        pickle.dump([labels.detach().cpu().numpy()], f)
+
+    print('****** DSV Data Generated ******')

--- a/src/data_generate/generate_data.py
+++ b/src/data_generate/generate_data.py
@@ -31,6 +31,7 @@ import torch
 torch.backends.cudnn.enabled = False
 
 from distill_data import generate_calib_centers, DistillData
+from dsv_synthesis import generate_dsv_data
 from collections import OrderedDict
 from pytorchcv.model_provider import get_model as ptcv_get_model
 
@@ -95,6 +96,15 @@ def arg_parse():
                         type=float,
                         default=0.0,
                         help='gamma')
+    parser.add_argument('--synth_method',
+                        type=str,
+                        default='model_inversion',
+                        choices=['model_inversion', 'dsv'],
+                        help='data synthesis method')
+    parser.add_argument('--dsv_iter', type=int, default=200,
+                        help='number of iterations for DSV synthesis')
+    parser.add_argument('--dsv_lr', type=float, default=0.1,
+                        help='learning rate for DSV synthesis')
     parser.add_argument('--save_path_head',
                         type=str,
                         default='',
@@ -223,19 +233,22 @@ if __name__ == '__main__':
         model = ptcv_get_model(args.model, pretrained=True)
         print('****** Full precision model loaded ******')
 
-    if args.lbns:
-        args.calib_centers = generate_calib_centers(args, model.cuda())
+    if args.synth_method == 'model_inversion':
+        if args.lbns:
+            args.calib_centers = generate_calib_centers(args, model.cuda())
 
-    DD = DistillData(args)
-    dataloader = DD.get_distil_data(
-        model_name=args.model,
-        teacher_model=model.cuda(),
-        batch_size=args.batch_size,
-        group=args.group,
-        beta=args.beta,
-        gamma=args.gamma,
-        save_path_head=args.save_path_head,
-        init_data_path=args.init_data_path
-    )
+        DD = DistillData(args)
+        DD.get_distil_data(
+            model_name=args.model,
+            teacher_model=model.cuda(),
+            batch_size=args.batch_size,
+            group=args.group,
+            beta=args.beta,
+            gamma=args.gamma,
+            save_path_head=args.save_path_head,
+            init_data_path=args.init_data_path
+        )
+    else:
+        generate_dsv_data(args, model.cuda())
 
     print('****** Data Generated ******')


### PR DESCRIPTION
## Summary
- allow choosing between model inversion and Deep Support Vector methods for synthetic data creation
- implement DSV-based synthesis with primal and stationarity losses

## Testing
- `python src/unit_test.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==2.0.1 --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch==2.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_6894333ff054832a918c33c4f3d222b9